### PR TITLE
Update plugin registration method

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.plugin_package}}/static/js/{{cookiecutter.plugin_identifier}}.js
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.plugin_package}}/static/js/{{cookiecutter.plugin_identifier}}.js
@@ -15,14 +15,15 @@ $(function() {
         // TODO: Implement your plugin's view model here.
     }
 
-    // view model class, parameters for constructor, container to bind to
-    OCTOPRINT_VIEWMODELS.push([
-        {{ cookiecutter.plugin_identifier | capitalize }}ViewModel,
-
-        // e.g. loginStateViewModel, settingsViewModel, ...
-        [ /* "loginStateViewModel", "settingsViewModel" */ ],
-
-        // e.g. #settings_plugin_{{ cookiecutter.plugin_identifier }}, #tab_plugin_{{ cookiecutter.plugin_identifier }}, ...
-        [ /* ... */ ]
-    ]);
+    /* view model class, parameters for constructor, container to bind to
+     * Please see http://docs.octoprint.org/en/master/plugins/viewmodels.html#registering-custom-viewmodels for more details
+     * and a full list of the available options.
+     */
+    OCTOPRINT_VIEWMODELS.push({
+        construct: {{ cookiecutter.plugin_identifier | capitalize }}ViewModel,
+        // ViewModels your plugin depends on, e.g. loginStateViewModel, settingsViewModel, ...
+        dependencies: [ /* "loginStateViewModel", "settingsViewModel" */ ],
+        // Elements to bind to, e.g. #settings_plugin_{{ cookiecutter.plugin_identifier }}, #tab_plugin_{{ cookiecutter.plugin_identifier }}, ...
+        elements: [ /* ... */ ]
+    });
 });


### PR DESCRIPTION
#### What does this PR do and why is it necessary? ####

[The documentation](http://docs.octoprint.org/en/master/plugins/viewmodels.html#registering-custom-viewmodels) lists a different method of registering a new view model, with the current template method being depreciated. This pull request updates the plugin template to be inline with the current documented view model registration method.

Remove old 3-tuple registration method and replace with new registration method to match the current documentation.

#### How was it tested? How can it be tested by the reviewer? ####

Tested by cloning the repository and create a simple test plugin

#### Any background context you want to provide? ####

n/a

#### What are the relevant tickets if any? ####

As discussed in hangouts.

#### Screenshots (if appropriate) ####

#### Further notes ####