### PR TITLE
 Added explanation on characters that break code

### DIFF
--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -3,7 +3,7 @@
 ########################################################################################################################
 ### Do not forget to adjust the following variables to your own plugin.
 
-# The plugin's identifier, has to be unique
+# The plugin's identifier, should not contain " ", "-" or "_", has to be unique
 plugin_identifier = "{{cookiecutter.plugin_identifier}}"
 
 # The plugin's python package, should be "octoprint_<plugin identifier>", has to be unique


### PR DESCRIPTION
Found that the hello world example breaks when using any of these, not sure why, but this would have saved me a lot of time. Is this change ok?