### PR TITLE
Cookiecutter improvements

### DIFF
--- a/{{cookiecutter.repo_name}}/.editorconfig
+++ b/{{cookiecutter.repo_name}}/.editorconfig
@@ -10,7 +10,8 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 [**.py]
-indent_style = tab
+indent_style = space
+indent_size = 4
 
 [**.js]
 indent_style = space

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -66,31 +66,35 @@ additional_setup_parameters = {}
 from setuptools import setup
 
 try:
-	import octoprint_setuptools
+    import octoprint_setuptools
 except:
-	print("Could not import OctoPrint's setuptools, are you sure you are running that under "
-	      "the same python installation that OctoPrint is installed under?")
-	import sys
-	sys.exit(-1)
+    print(
+        "Could not import OctoPrint's setuptools, are you sure you are running that under "
+        "the same python installation that OctoPrint is installed under?"
+    )
+    import sys
+
+    sys.exit(-1)
 
 setup_parameters = octoprint_setuptools.create_plugin_setup_parameters(
-	identifier=plugin_identifier,
-	package=plugin_package,
-	name=plugin_name,
-	version=plugin_version,
-	description=plugin_description,
-	author=plugin_author,
-	mail=plugin_author_email,
-	url=plugin_url,
-	license=plugin_license,
-	requires=plugin_requires,
-	additional_packages=plugin_additional_packages,
-	ignored_packages=plugin_ignored_packages,
-	additional_data=plugin_additional_data
+    identifier=plugin_identifier,
+    package=plugin_package,
+    name=plugin_name,
+    version=plugin_version,
+    description=plugin_description,
+    author=plugin_author,
+    mail=plugin_author_email,
+    url=plugin_url,
+    license=plugin_license,
+    requires=plugin_requires,
+    additional_packages=plugin_additional_packages,
+    ignored_packages=plugin_ignored_packages,
+    additional_data=plugin_additional_data,
 )
 
 if len(additional_setup_parameters):
-	from octoprint.util import dict_merge
-	setup_parameters = dict_merge(setup_parameters, additional_setup_parameters)
+    from octoprint.util import dict_merge
+
+    setup_parameters = dict_merge(setup_parameters, additional_setup_parameters)
 
 setup(**setup_parameters)

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.plugin_package}}/__init__.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.plugin_package}}/__init__.py
@@ -12,48 +12,49 @@ from __future__ import absolute_import
 import octoprint.plugin
 
 class {{ cookiecutter.plugin_identifier | capitalize }}Plugin(octoprint.plugin.SettingsPlugin,
-      {{ " " * cookiecutter.plugin_identifier | length }}       octoprint.plugin.AssetPlugin,
-      {{ " " * cookiecutter.plugin_identifier | length }}       octoprint.plugin.TemplatePlugin):
+    octoprint.plugin.AssetPlugin,
+    octoprint.plugin.TemplatePlugin
+):
 
-	##~~ SettingsPlugin mixin
+    ##~~ SettingsPlugin mixin
 
-	def get_settings_defaults(self):
-		return dict(
-			# put your plugin's default settings here
-		)
+    def get_settings_defaults(self):
+        return {
+            # put your plugin's default settings here
+        }
 
-	##~~ AssetPlugin mixin
+    ##~~ AssetPlugin mixin
 
-	def get_assets(self):
-		# Define your plugin's asset files to automatically include in the
-		# core UI here.
-		return dict(
-			js=["js/{{ cookiecutter.plugin_identifier }}.js"],
-			css=["css/{{ cookiecutter.plugin_identifier }}.css"],
-			less=["less/{{ cookiecutter.plugin_identifier }}.less"]
-		)
+    def get_assets(self):
+        # Define your plugin's asset files to automatically include in the
+        # core UI here.
+        return {
+            "js": ["js/{{ cookiecutter.plugin_identifier }}.js"],
+            "css": ["css/{{ cookiecutter.plugin_identifier }}.css"],
+            "less": ["less/{{ cookiecutter.plugin_identifier }}.less"]
+        }
 
-	##~~ Softwareupdate hook
+    ##~~ Softwareupdate hook
 
-	def get_update_information(self):
-		# Define the configuration for your plugin to use with the Software Update
-		# Plugin here. See https://docs.octoprint.org/en/master/bundledplugins/softwareupdate.html
-		# for details.
-		return dict(
-			{{ cookiecutter.plugin_identifier }}=dict(
-				displayName="{{ cookiecutter.plugin_identifier | capitalize }} Plugin",
-				displayVersion=self._plugin_version,
+    def get_update_information(self):
+        # Define the configuration for your plugin to use with the Software Update
+        # Plugin here. See https://docs.octoprint.org/en/master/bundledplugins/softwareupdate.html
+        # for details.
+        return {
+            "{{ cookiecutter.plugin_identifier }}": {
+                "displayName": "{{ cookiecutter.plugin_identifier | capitalize }} Plugin",
+                "displayVersion": self._plugin_version,
 
-				# version check: github repository
-				type="github_release",
-				user="{{cookiecutter.github_username}}",
-				repo="{{cookiecutter.repo_name}}",
-				current=self._plugin_version,
+                # version check: github repository
+                "type": "github_release",
+                "user": "{{cookiecutter.github_username}}",
+                "repo": "{{cookiecutter.repo_name}}",
+                "current": self._plugin_version,
 
-				# update method: pip
-				pip="https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.repo_name}}/archive/{target_version}.zip"
-			)
-		)
+                # update method: pip
+                "pip": "https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.repo_name}}/archive/{target_version}.zip",
+            }
+        }
 
 
 # If you want your plugin to be registered within OctoPrint under a different name than what you defined in setup.py
@@ -69,11 +70,10 @@ __plugin_name__ = "{{ cookiecutter.plugin_identifier | capitalize }} Plugin"
 #__plugin_pythoncompat__ = ">=2.7,<4" # python 2 and 3
 
 def __plugin_load__():
-	global __plugin_implementation__
-	__plugin_implementation__ = {{ cookiecutter.plugin_identifier | capitalize }}Plugin()
+    global __plugin_implementation__
+    __plugin_implementation__ = {{ cookiecutter.plugin_identifier | capitalize }}Plugin()
 
-	global __plugin_hooks__
-	__plugin_hooks__ = {
-		"octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information
-	}
-
+    global __plugin_hooks__
+    __plugin_hooks__ = {
+        "octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information
+    }


### PR DESCRIPTION
- Switch to spaces for indentation to match formatting of OctoPrint source (black).
- Use dictionary constants instead of dict()