### PR TITLE
Add sample GitHub issue templates

### DIFF
--- a/{{cookiecutter.repo_name}}/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/{{cookiecutter.repo_name}}/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,96 @@
+name: 🐛 Report a bug
+description: Create a bug report to help improve {{cookiecutter.plugin_name}}
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        **Thank you for wanting to report a bug in {{cookiecutter.plugin_name}}!**
+
+          * First, be sure you are running the [latest version of the {{cookiecutter.plugin_name}} plugin](https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.repo_name}}/releases).
+          * You will also need to [enable debugging on the plugin](https://docs.octoprint.org/en/master/configuration/logging_yaml.html).
+            * This may be done through the *Settings* > *OctoPrint* > *Logging* > *Logging Levels* section.
+            * Select the "octoprint.plugins.{{cookiecutter.plugin_identifier}}" Name, and make sure Level is "DEBUG".
+            * Save, then restart OctoPrint, which allows the developers to see debug information from the moment the plugin is loaded.
+          * Finally, when submitting a bug report, you **must** [include a Systeminfo Bundle](https://community.octoprint.org/t/what-is-a-systeminfo-bundle-and-how-can-i-obtain-one/29887), generated after the point the bug occurs. This allows the developers to examine the debug logs produced from your plugin installation.
+
+        Thank you for your help!
+  - type: textarea
+    attributes:
+      label: The problem
+      description: >-
+        Describe the issue you are experiencing here. Tell us what you were trying to do
+        step by step, and what happened that you did not expect.
+
+        Provide a clear and concise description of what the problem is and include as many
+        details as possible.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        ## Environment
+  - type: input
+    attributes:
+      label: Version of {{cookiecutter.plugin_name}}
+      description: Can be found in *Settings* > *Plugin Manager*, next to "{{cookiecutter.plugin_name}}".
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Version of OctoPrint
+      description: Can be found in the lower left corner of the web interface.
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Operating system running OctoPrint
+      description: >-
+        OctoPi, Linux, Windows, MacOS, something else? With version please? OctoPi's
+        version can be found in `/etc/octopi_version` or in the lower left corner of the
+        web interface.
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Printer model & used firmware incl. version
+      description: If applicable, always include if unsure
+  - type: input
+    attributes:
+      label: Browser and version of browser, operating system running browser
+      description: If applicable, always include if unsure
+  - type: markdown
+    attributes:
+      value: |
+        ## Logs and other files needed for analysis
+  - type: markdown
+    attributes:
+      value: >-
+        Please also be sure to upload the following files below:
+
+          * Systeminfo Bundle: See [here](https://community.octoprint.org/t/what-is-a-systeminfo-bundle-and-how-can-i-obtain-one/29887) if you don't know where to find that. Just attach down below as-is. Note that you'll need at least OctoPrint 1.6.0 for this to be available - we no longer accept bug reports created for older versions than this.
+            * If you are reporting an issue that involves communicating with you printer, **be sure to enable `serial.log` before reproducing and creating the Systeminfo Bundle**!
+          * Your browser's JavaScript console, if you are reporting a problem with the
+            user interface. See [here](https://webmasters.stackexchange.com/questions/8525/how-to-open-the-javascript-console-in-different-browsers) on where to find that.
+          * If possible, screenshots or videos showing the problem, especially if you
+            are reporting a problem with the user interface!
+          * GCODE files with which to reproduce, if you are reporting an issue with
+            GCODE file analysis or printing behaviour.
+
+        Please be aware that unless at least Systeminfo Bundle is included, your bug report
+        will not be processed and closed after a while.
+  - type: checkboxes
+    attributes:
+      label: Checklist of files to include below
+      options:
+        - label: Systeminfo Bundle (always include!)
+          required: true
+        - label: Contents of the JavaScript browser console (always include in cases of issues with the user interface)
+        - label: Screenshots and/or videos showing the problem (always include in case of issues with the user interface)
+        - label: GCODE file with which to reproduce (always include in case of issues with GCODE analysis or printing behaviour)
+  - type: textarea
+    attributes:
+      label: Additional information & file uploads

--- a/{{cookiecutter.repo_name}}/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/{{cookiecutter.repo_name}}/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,26 @@
+name: ✨ Request a feature
+description: Request a new feature to implement in {{cookiecutter.plugin_name}}
+title: "[Request]"
+body:
+  - type: markdown
+    attributes:
+      value: >
+        **Thank you for wanting to request a feature in {{cookiecutter.plugin_name}}!**
+  - type: textarea
+    attributes:
+      label: Is your feature request related to a problem? Please describe.
+      description: A clear and concise description of what the problem is. Eg, "I'm always frustrated when [...]".
+  - type: textarea
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
These templates are mostly copied from OctoPrint's own templates, but are
adapted to suit a plugin repository. Most notably, the bug_report includes
instructions on how to enable debug logging for the plugin.

The feature_request is also similar to OctoPrint's but does not try to
steer the user toward plugins, because, well... :)