### PR TITLE
Default plugin template to Python 3 only

### DIFF
--- a/{{cookiecutter.repo_name}}/extras/{{cookiecutter.plugin_identifier}}.md
+++ b/{{cookiecutter.repo_name}}/extras/{{cookiecutter.plugin_identifier}}.md
@@ -29,6 +29,7 @@ tags:
 - (take a look at the existing plugins for what makes sense here)
 
 # TODO
+# When registering a plugin on plugins.octoprint.org, all screenshots should be uploaded not linked from external sites.
 screenshots:
 - url: url of a screenshot, /assets/img/...
   alt: alt-text of a screenshot
@@ -59,7 +60,7 @@ compatibility:
   # OctoPrint versions being supported.
 
   octoprint:
-  - 1.2.0
+  - 1.4.0
 
   # List of compatible operating systems
   #
@@ -86,15 +87,13 @@ compatibility:
 
   # Compatible Python version
   #
-  # Plugins should aim for compatibility for Python 2 and 3 for now, in which case the value should be ">=2.7,<4".
+  # It is recommended to only support Python 3 for new plugins, in which case this should be ">=3,<4"
+  # 
+  # Plugins that wish to support both Python 2 and 3 should set it to ">=2.7,<4".
   #
-  # Plugins that only wish to support Python 3 should set it to ">=3,<4".
-  #
-  # If your plugin only supports Python 2 (worst case, not recommended for newly developed plugins since Python 2
-  # is EOL), leave at ">=2.7,<3" - be aware that your plugin will not be allowed to register on the
-  # plugin repository if it only support Python 2.
+  # Plugins that only support Python 2 will not be accepted into the plugin repository.
 
-  python: ">=2.7,<3"
+  python: ">=3,<4"
 
 ---
 

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -59,7 +59,9 @@ plugin_ignored_packages = []
 # Example:
 #     plugin_requires = ["someDependency==dev"]
 #     additional_setup_parameters = {"dependency_links": ["https://github.com/someUser/someRepo/archive/master.zip#egg=someDependency-dev"]}
-additional_setup_parameters = {}
+# "python_requires": ">=3,<4" blocks installation on Python 2 systems, to prevent confused users and provide a helpful error. 
+# Remove it if you would like to support Python 2 as well as 3 (not recommended).
+additional_setup_parameters = {"python_requires": ">=3,<4"}
 
 ########################################################################################################################
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.plugin_package}}/__init__.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.plugin_package}}/__init__.py
@@ -62,12 +62,11 @@ class {{ cookiecutter.plugin_identifier | capitalize }}Plugin(octoprint.plugin.S
 # can be overwritten via __plugin_xyz__ control properties. See the documentation for that.
 __plugin_name__ = "{{ cookiecutter.plugin_identifier | capitalize }} Plugin"
 
-# Starting with OctoPrint 1.4.0 OctoPrint will also support to run under Python 3 in addition to the deprecated
-# Python 2. New plugins should make sure to run under both versions for now. Uncomment one of the following
-# compatibility flags according to what Python versions your plugin supports!
-#__plugin_pythoncompat__ = ">=2.7,<3" # only python 2
-#__plugin_pythoncompat__ = ">=3,<4" # only python 3
-#__plugin_pythoncompat__ = ">=2.7,<4" # python 2 and 3
+
+# Set the Python version your plugin is compatible with below. Recommended is Python 3 only for all new plugins.
+# OctoPrint 1.4.0 - 1.7.x run under both Python 3 and the end-of-life Python 2.
+# OctoPrint 1.8.0 onwards only supports Python 3.
+__plugin_pythoncompat__ = ">=3,<4"  # Only Python 3
 
 def __plugin_load__():
     global __plugin_implementation__


### PR DESCRIPTION
14 of the last 20 plugins registered were Python 3 only, and OctoPrint 1.8.0 will drop support (in case you needed a reminder :partying_face: :tada:)