### PR TITLE
Added a 'pre_gen' hook to validate input

### DIFF
--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,0 +1,17 @@
+import re
+import sys
+
+# Dashes '-' are technically allowed, but require special import and would generate invalid code with this template
+MODULE_REGEX = r"^[_a-zA-Z][_a-zA-Z0-9]+$"
+
+# These names are used as class/module names in the template and therefore need to adhere to the given regex
+names_to_check = [
+    "{{ cookiecutter.plugin_identifier }}",
+    "{{ cookiecutter.plugin_package }}",
+]
+
+for name in names_to_check:
+    if not re.match(MODULE_REGEX, name):
+        print(f"ERROR: '{name}' is not a valid Python module name!")
+        print("Please only use a-z, A-Z, underscores and numbers (except for the first character)")
+        sys.exit(1)


### PR DESCRIPTION
This will check a few of the input variables from Cookiecutter if they are valid Python module/class names so we won't generate invalid code.

I ran into this issue today, because I entered a `-` in the name of my plugin and then cookiecutter generated invalid Python code.

Technically a dash is okay, but it's not recommended and would require a special import syntax so I assumed that validating the names with a slightly stricter regex will also avoid more problems down the road.


Best,
Felix